### PR TITLE
Fix the orientation issue

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BaseReaderFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BaseReaderFragment.kt
@@ -25,8 +25,15 @@ abstract class BaseReaderFragment<B : ViewBinding> : BaseFragment<B>(), ZoomCont
 		readerAdapter = onCreateAdapter()
 
 		viewModel.content.observe(viewLifecycleOwner) {
+			// Use getCurrentState() to handle configuration changes (e.g., screen rotation) properly.
+			// getCurrentState() always has the most recent reading position, while content.state
+			// may contain the initial state from when content was first loaded.
+			val currentState = viewModel.getCurrentState()
 			if (it.state == null && it.pages.isNotEmpty() && readerAdapter?.hasItems != true) {
-				onPagesChanged(it.pages, viewModel.getCurrentState())
+				onPagesChanged(it.pages, currentState)
+			} else if (currentState != null) {
+				// If we have a current state, use it instead of content.state
+				onPagesChanged(it.pages, currentState)
 			} else {
 				onPagesChanged(it.pages, it.state)
 			}


### PR DESCRIPTION
In the base reader fragment, using `getCurrentState()` instead of `it.state ` when the orientation is changed. It ensures that the restored page is the last saved one in SavedStateHandle instead of the one we got to when clicking Continue.